### PR TITLE
Add switch-colon-spacing rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 Changelog
 ---------
 
+# 0.0.5
+
+Add the switch-colon-spacing rule.
+
 # 0.0.4
 
 Remove some ignorePatterns that shouldn't be ignored.

--- a/index.js
+++ b/index.js
@@ -203,7 +203,8 @@ const rules = {
   "object-shorthand": [ "error", "properties" ], // make it short
   "object-curly-spacing": [ "error", "always" ], // consistency
   "array-bracket-spacing": [ "error", "always" ], // consistency with above
-  "new-cap": "error" // consistency with test rules
+  "new-cap": "error", // consistency with test rules
+  "switch-colon-spacing": "error"
 };
 
 module.exports = {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-exp",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "description": "ESLint config",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Forces a space after colon in switch statements.