### PR TITLE
make indenting jsx props mandatory

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.6.1
+
+- Added `"react/jsx-indent-props": [2, 2]` as a rule for react to make indenting jsx props look nice.
+
 ## 0.6.0
 
 - Added support for react using `exp/react`.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "eslint-config-exp",
-  "version": "0.6.0",
+  "version": "0.6.1",
   "description": "ESLint config",
   "main": "index.js",
   "scripts": {

--- a/react.js
+++ b/react.js
@@ -46,6 +46,7 @@ module.exports = {
         "react/function-component-definition": [ 2, { namedComponents: "function-declaration", unnamedComponents: "arrow-function" } ],
         "react/jsx-indent": [ 2, 2 ],
         "react/jsx-tag-spacing": [ 2, { beforeSelfClosing: "always" } ],
+        "react/jsx-indent-props": [ 2, 2 ],
       },
     },
   ],


### PR DESCRIPTION
Adding rule https://github.com/jsx-eslint/eslint-plugin-react/blob/master/docs/rules/jsx-indent-props.md.

Makes indenting something with jsx props on newlines look something like:

```jsx
<div
   data-test-references
   data-reference-type={propertyDefinition.referenceType}
   data-max-values={maxValues}
   data-min-values={minValues}
   className="autocomplete bg-white rounded border border-gray-600 p-1 flex-1 flex flex-wrap relative outline-none focus-within:border-blue-500"
 >
```

i.e. align props with the div